### PR TITLE
Fix task 4 URL encoding

### DIFF
--- a/lab.tex
+++ b/lab.tex
@@ -172,7 +172,7 @@ Here's a very basic example page:
 
 Once you've done this, you can find your shiny new webpage at:
 
-\qquad \texttt{https://dcs.warwick.ac.uk/$\sim$u[your student id]}
+\qquad \nolinkurl{https://dcs.warwick.ac.uk/~u[your student id]}
 
 ...or at least you would, if you had the permissions to access it.
 


### PR DESCRIPTION
Copy+pasting URL in task 4 doesn't work as the tilde encoding changes. Using \nolinkurl fixes this